### PR TITLE
Update Dockerfile to build prisma

### DIFF
--- a/listing-service/Dockerfile
+++ b/listing-service/Dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/nashtech-garage/nodejs-msa/listing:build as builder
 
 COPY . .
 
+RUN npx prisma generate
 RUN npm run build
-
 
 # Prod stage
 FROM ghcr.io/nashtech-garage/nodejs-msa/listing:release


### PR DESCRIPTION
Listing Service build fail in GitAction, because we don't run prisma generate.